### PR TITLE
feat: add support for bots that 'only' support text/html

### DIFF
--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -1,0 +1,1 @@
+docker-compose.dev.yml

--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -1,1 +1,0 @@
-docker-compose.dev.yml

--- a/internal/methods/create.go
+++ b/internal/methods/create.go
@@ -1,6 +1,8 @@
 package methods
 
 import (
+	"strings"
+
 	"github.com/Escape-Technologies/http-request-catcher/internal/schema"
 	"github.com/Escape-Technologies/http-request-catcher/pkg/database"
 	"github.com/gin-gonic/gin"
@@ -8,22 +10,36 @@ import (
 
 const (
 	DefaultMessage = "H@k3d!"
+	HTMLMessage    = "<html><body><h1>H@k3d!</h1></body></html>"
 )
 
 // Create an entry for the current context.
 func CreateBucketEntry(c *gin.Context) {
 	requestData := schema.FormatBucketEntry(c)
 	if requestData == nil {
-		c.JSON(500, gin.H{
-			"message": DefaultMessage,
-		})
-
+		respondBasedOnAcceptHeader(c, 500, DefaultMessage)
 		return
 	}
 
 	go database.StoreRequest(requestData)
 
-	c.JSON(200, gin.H{
-		"message": DefaultMessage,
-	})
+	respondBasedOnAcceptHeader(c, 200, DefaultMessage)
+}
+
+// respondBasedOnAcceptHeader responds based on the Accept header
+func respondBasedOnAcceptHeader(c *gin.Context, statusCode int, message string) {
+	acceptHeader := c.GetHeader("Accept")
+
+	if strings.Contains(acceptHeader, "application/json") {
+		c.JSON(statusCode, gin.H{
+			"message": message,
+		})
+	} else if strings.Contains(acceptHeader, "text/html") {
+		c.Data(statusCode, "text/html", []byte(HTMLMessage))
+	} else {
+		// Default to JSON if no specific type is requested
+		c.JSON(statusCode, gin.H{
+			"message": message,
+		})
+	}
 }


### PR DESCRIPTION
Some bot's such as chatGPT do not support `application/json` but support `text/html` so this should add support when we try and make CSRF with bots that have peculiar requirements.