### PR TITLE
chore: --rm-dist deprecated

### DIFF
--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -23,7 +23,7 @@ jobs:
       - name: Create release on GitHub
         uses: goreleaser/goreleaser-action@v2
         with:
-          args: "release --rm-dist"
+          args: "release --clean"
           version: latest
         env:
           GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"

--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,7 @@ test:
 
 .PHONY: release
 release:
-	goreleaser release --snapshot --rm-dist
+	goreleaser release --snapshot --clean
 
 .PHONY: compose
 compose:


### PR DESCRIPTION
`--rm-dist` is deprecated in favor of `--clean`

https://goreleaser.com/deprecations/#-rm-dist