### PR TITLE
chore: golanci cache handling was broken - updating it

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -24,7 +24,7 @@ jobs:
       - name: Lint
         uses: golangci/golangci-lint-action@v6
         with:
-          version: v1.0
+          version: v1.59
 
   report:
     name: Report

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -22,9 +22,9 @@ jobs:
         run: make
 
       - name: Lint
-        uses: golangci/golangci-lint-action@v3
+        uses: golangci/golangci-lint-action@v6
         with:
-          version: v1.46.0
+          version: v1.0
 
   report:
     name: Report


### PR DESCRIPTION
Cache handling was broken, updating to latest version should fix it. (cf [issues on it's repo](https://github.com/golangci/golangci-lint-action/issues/135))

Not sure if it will break other things in the CI.